### PR TITLE
Add instructions footer to sales analysis page

### DIFF
--- a/analise-de-venda.html
+++ b/analise-de-venda.html
@@ -14,6 +14,13 @@
     button { padding:8px 16px; border:none; background:#f1c40f; cursor:pointer; border-radius:4px; font-weight:bold; }
     input.valor-venda { width:80px; padding:4px; border:1px solid #ccc; border-radius:4px; }
     input.valor-venda[disabled] { background:#eee; }
+    footer {
+      background-color: #333;
+      color: #fff;
+      text-align: center;
+      padding: 10px;
+      font-size: 12px;
+    }
   </style>
 </head>
 <body>
@@ -127,8 +134,8 @@
       localStorage.setItem('produtosCalculados', JSON.stringify(dadosProdutos));
       calcular();
     });
-    document.getElementById('taxaCartao').addEventListener('input', habilitar);
-    document.getElementById('regime').addEventListener('change', habilitar);
+  document.getElementById('taxaCartao').addEventListener('input', habilitar);
+  document.getElementById('regime').addEventListener('change', habilitar);
 
     function habilitar(){
       if(document.getElementById('taxaCartao').value && document.getElementById('regime').value){
@@ -138,5 +145,14 @@
     }
   });
 </script>
+<footer>
+  <p><strong>Como funciona:</strong> Esta página auxilia na formação do preço de venda e no cálculo do lucro.</p>
+  <ol>
+    <li>Informe a <em>Taxa Cartão</em> e selecione o <em>Regime</em> tributário.</li>
+    <li>Digite o <em>Valor de Venda</em> para cada produto e ajuste as quantidades.</li>
+    <li>Acompanhe o custo total, markup e lucro efetivo calculados automaticamente.</li>
+  </ol>
+  <p>As alíquotas de cada regime devem ser solicitadas à contabilidade.</p>
+</footer>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- style footer for analise-de-venda.html
- explain how to use the sales analysis page and mention to request aliquotas from accounting

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685302dee65883279aa3d8672f826c54