### PR TITLE
Fix analysis data persistence

### DIFF
--- a/analise-de-venda.html
+++ b/analise-de-venda.html
@@ -46,7 +46,15 @@
     <tbody></tbody>
   </table>
 <script>
-  let dadosProdutos = JSON.parse(localStorage.getItem('produtosCalculados') || '[]');
+  let dadosProdutos = [];
+  try {
+    dadosProdutos = JSON.parse(window.name || '[]');
+    if (!dadosProdutos.length) {
+      dadosProdutos = JSON.parse(localStorage.getItem('produtosCalculados') || '[]');
+    }
+  } catch (e) {
+    dadosProdutos = JSON.parse(localStorage.getItem('produtosCalculados') || '[]');
+  }
   let ncmMap = {};
   fetch('https://opensheet.vercel.app/1TKysjAxeh72sSwAsa7qutZ1SUUvpazAgCNNlsMx-H00/Página1')
     .then(res => res.json())
@@ -125,6 +133,7 @@
     qtdInput.addEventListener('input', () => {
       p.quantidade = parseFloat(qtdInput.value) || 0;
       localStorage.setItem('produtosCalculados', JSON.stringify(dadosProdutos));
+      window.name = JSON.stringify(dadosProdutos);
       calcular();
     });
     document.getElementById('taxaCartao').addEventListener('input', habilitar);

--- a/index.html
+++ b/index.html
@@ -279,6 +279,7 @@
                   margemLP: categoria.margemLP
                 };
                 localStorage.setItem('produtosCalculados', JSON.stringify(produtosCalculados));
+                window.name = JSON.stringify(produtosCalculados);
               };
               let percEfetivo = valorProd > 0 ? (icmsST / valorProd) * 100 : 0;
 
@@ -301,6 +302,7 @@
 
         document.getElementById('totalImpostoInfo').textContent = `Total Imposto: ${totalImpostoNota.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' })}`;
         localStorage.setItem('produtosCalculados', JSON.stringify(produtosCalculados));
+        window.name = JSON.stringify(produtosCalculados);
       };
       reader.readAsText(file);
     });


### PR DESCRIPTION
## Summary
- share parsed products data using `window.name`
- fall back to localStorage when loading from the analysis page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68533fe23e8083278ea1545fd6bc61cd