### PR TITLE
Adjust NCM lookup to use 8 digits

### DIFF
--- a/analise-de-venda.html
+++ b/analise-de-venda.html
@@ -60,9 +60,9 @@ index 64f3bc247d4dbc974c99ff2de968ab579d9774d6..b31c00baaedf92b3985b1dd6e323e85f
      .then(rows => {
        console.log("Dados da planilha:", rows);
        rows.forEach(r => {
-         const prefix = r.prefixo;
-         if (prefix) {
-           ncmMap[prefix] = {
+         const codigo = r.prefixo;
+         if (codigo) {
+           ncmMap[codigo] = {
              descricao: r.descricao,
              mva: parseFloat((r.mva || '0').replace(',', '.')) || 0,
              margemSN: parseFloat((r.SN || r.sn || '0').replace(',', '.')) || 0,

--- a/index.html
+++ b/index.html
@@ -145,9 +145,9 @@
       .then(rows => {
         console.log("Dados da planilha:", rows);
         rows.forEach(r => {
-          const prefix = r.prefixo;
-          if (prefix) {
-            ncmMvaMap[prefix] = {
+          const codigo = r.prefixo;
+          if (codigo) {
+            ncmMvaMap[codigo] = {
               descricao: r.descricao,
               mva: parseFloat((r.mva || '0').replace(',', '.')) || 0,
               margemSN: parseFloat((r.SN || r.sn || '0').replace(',', '.')) || 0,
@@ -191,8 +191,7 @@
           const desconto = parseFloat(prod.getElementsByTagName('vDesc')[0]?.textContent || '0');
           const cfop = prod.getElementsByTagName('CFOP')[0]?.textContent || '';
           const ncm = prod.getElementsByTagName('NCM')[0]?.textContent || '00000000';
-          const prefixo = ncm.substring(0, 4);
-          const categoria = ncmMvaMap[prefixo];
+          const categoria = ncmMvaMap[ncm];
 
           const impostoTag = prod.parentNode.querySelector('ICMS, ICMSSN101, ICMSSN102');
           let cst = '000';


### PR DESCRIPTION
## Summary
- map spreadsheet entries by full `NCM` code
- search for categories using the entire NCM instead of prefix

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68538e93df308327bd2121f89b1167d2